### PR TITLE
Small improvements

### DIFF
--- a/api/src/DataPersister/ContentNode/ColumnLayoutDataPersister.php
+++ b/api/src/DataPersister/ContentNode/ColumnLayoutDataPersister.php
@@ -27,7 +27,9 @@ class ColumnLayoutDataPersister extends ContentNodeAbstractDataPersister {
                 throw new \Exception('Prototype must be of type ColumnLayout');
             }
 
-            $data->copyFromPrototype($data->prototype);
+            if (!isset($data->columns)) {
+                $data->columns = $data->prototype->columns;
+            }
         }
 
         return parent::beforeCreate($data);

--- a/api/src/DataPersister/ContentNode/SingleTextDataPersister.php
+++ b/api/src/DataPersister/ContentNode/SingleTextDataPersister.php
@@ -27,11 +27,8 @@ class SingleTextDataPersister extends ContentNodeAbstractDataPersister {
                 throw new \Exception('Prototype must be of type SingleText');
             }
 
-            /** @var SingleText $prototype */
-            $prototype = $data->prototype;
-
             if (!isset($data->text)) {
-                $data->text = $prototype->text;
+                $data->text = $data->prototype->text;
             }
         }
 

--- a/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
+++ b/api/src/DataPersister/ContentNode/StoryboardDataPersister.php
@@ -28,11 +28,8 @@ class StoryboardDataPersister extends ContentNodeAbstractDataPersister {
                 throw new \Exception('Prototype must be of type Storyboard');
             }
 
-            /** @var Storyboard $prototype */
-            $prototype = $storyboard->prototype;
-
             // copy all storyboard sections
-            foreach ($prototype->sections as $prototypeSection) {
+            foreach ($storyboard->prototype->sections as $prototypeSection) {
                 $section = new StoryboardSection();
 
                 $section->column1 = $prototypeSection->column1;

--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -13,6 +13,7 @@ use App\Validator\ColumnLayout\ColumnLayoutPatchGroupSequence;
 use App\Validator\ColumnLayout\ColumnLayoutPostGroupSequence;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\SerializedName;
 
 /**
  * @ORM\Entity(repositoryClass=ColumnLayoutRepository::class)
@@ -68,14 +69,15 @@ class ColumnLayout extends ContentNode {
      *
      * @ORM\Column(type="json", nullable=true)
      */
-    #[ApiProperty(example: "[['slot' => '1', 'width' => 12]]")]
+    #[ApiProperty(example: [['slot' => '1', 'width' => 12]])]
     #[Groups(['read', 'write'])]
-    private ?array $columns = null;
+    public ?array $columns = null;
 
     #[AssertJsonSchema(schema: ColumnLayout::COLUMNS_SCHEMA, groups: ['columns_schema'])]
     #[AssertColumWidthsSumTo12]
     #[AssertNoOrphanChildren]
-    public function getColumns(): ?array {
+    #[SerializedName('columns')]
+    public function getColumnsFromThisOrPrototype(): ?array {
         if (null !== $this->prototype && null === $this->columns) {
             return $this->prototype->columns;
         }
@@ -83,13 +85,9 @@ class ColumnLayout extends ContentNode {
         return $this->columns;
     }
 
-    public function setColumns(?array $columns) {
-        $this->columns = $columns;
-    }
-
     public function copyFromPrototype(ColumnLayout $prototype) {
         if (!isset($this->columns)) {
-            $this->columns = $prototype->getColumns();
+            $this->columns = $prototype->columns;
         }
     }
 }

--- a/api/src/Entity/ContentNode/ColumnLayout.php
+++ b/api/src/Entity/ContentNode/ColumnLayout.php
@@ -84,10 +84,4 @@ class ColumnLayout extends ContentNode {
 
         return $this->columns;
     }
-
-    public function copyFromPrototype(ColumnLayout $prototype) {
-        if (!isset($this->columns)) {
-            $this->columns = $prototype->columns;
-        }
-    }
 }

--- a/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/CreateColumnLayoutTest.php
@@ -80,7 +80,7 @@ class CreateColumnLayoutTest extends CreateContentNodeTestCase {
 
         $this->assertResponseStatusCodeSame(201);
         $this->assertJsonContains([
-            'columns' => $prototype->getColumns(),
+            'columns' => $prototype->columns,
             'instanceName' => $prototype->instanceName,
             'slot' => $prototype->slot,
             'position' => $prototype->position,

--- a/api/tests/Api/ContentNodes/ColumnLayout/ReadColumnLayoutTest.php
+++ b/api/tests/Api/ContentNodes/ColumnLayout/ReadColumnLayoutTest.php
@@ -27,7 +27,7 @@ class ReadColumnLayoutTest extends ReadContentNodeTestCase {
         // then
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
-            'columns' => $contentNode->getColumns(),
+            'columns' => $contentNode->columns,
             '_links' => [
                 'children' => ['href' => '/content_nodes?parent='.$this->getIriFor('columnLayoutChild1')],
             ],

--- a/api/tests/DataPersister/ContentNodes/ColumnLayoutDataPersisterTest.php
+++ b/api/tests/DataPersister/ContentNodes/ColumnLayoutDataPersisterTest.php
@@ -27,7 +27,7 @@ class ColumnLayoutDataPersisterTest extends TestCase {
         $this->contentNode->parent->root = $this->root;
 
         $this->contentNode->prototype = new ColumnLayout();
-        $this->contentNode->prototype->setColumns([['width' => 12, 'slot' => 'footer']]);
+        $this->contentNode->prototype->columns = [['width' => 12, 'slot' => 'footer']];
 
         $this->contentNode->prototype->instanceName = 'instance';
         $this->contentNode->prototype->slot = 'left';
@@ -62,7 +62,7 @@ class ColumnLayoutDataPersisterTest extends TestCase {
         $data = $this->dataPersister->beforeCreate($this->contentNode);
 
         // then
-        $this->assertEquals($data->getColumns(), $this->contentNode->prototype->getColumns());
+        $this->assertEquals($data->columns, $this->contentNode->prototype->columns);
 
         $this->assertEquals($data->instanceName, $this->contentNode->prototype->instanceName);
         $this->assertEquals($data->slot, $this->contentNode->prototype->slot);
@@ -72,7 +72,7 @@ class ColumnLayoutDataPersisterTest extends TestCase {
 
     public function testDoesNotOverrideDataOnCreate() {
         // given
-        $this->contentNode->setColumns([['width' => 12, 'slot' => 'header']]);
+        $this->contentNode->columns = [['width' => 12, 'slot' => 'header']];
         $this->contentNode->instanceName = 'testInstance';
         $this->contentNode->slot = 'right';
         $this->contentNode->position = 51;
@@ -83,7 +83,7 @@ class ColumnLayoutDataPersisterTest extends TestCase {
         $data = $this->dataPersister->beforeCreate($this->contentNode);
 
         // then
-        $this->assertNotEquals($data->getColumns(), $this->contentNode->prototype->getColumns());
+        $this->assertNotEquals($data->columns, $this->contentNode->prototype->columns);
 
         $this->assertNotEquals($data->instanceName, $this->contentNode->prototype->instanceName);
         $this->assertNotEquals($data->slot, $this->contentNode->prototype->slot);


### PR DESCRIPTION
Resets ColumnLayout->$columns to public, while the validations still run on a getter, which is now more appropriately named.