### PR TITLE
chore(api): performance baseline

### DIFF
--- a/api/migrations/schema/Version20220416125104.php
+++ b/api/migrations/schema/Version20220416125104.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220416125104 extends AbstractMigration {
+    public function getDescription(): string {
+        return 'add indexed for searchable properties';
+    }
+
+    public function up(Schema $schema): void {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX IDX_C19442309AF2EB23 ON camp (isPrototype)');
+        $this->addSql('CREATE INDEX IDX_C93898A7B00651C ON camp_collaboration (status)');
+        $this->addSql('CREATE INDEX IDX_D7785D2CA1CB398B ON schedule_entry (startOffset)');
+        $this->addSql('CREATE INDEX IDX_D7785D2CA501647F ON schedule_entry (endOffset)');
+    }
+
+    public function down(Schema $schema): void {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP INDEX IDX_D7785D2CA1CB398B');
+        $this->addSql('DROP INDEX IDX_D7785D2CA501647F');
+        $this->addSql('DROP INDEX IDX_C19442309AF2EB23');
+        $this->addSql('DROP INDEX IDX_C93898A7B00651C');
+    }
+}

--- a/api/src/Entity/Camp.php
+++ b/api/src/Entity/Camp.php
@@ -49,6 +49,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 #[ApiFilter(SearchFilter::class, properties: ['isPrototype'])]
 #[ORM\Entity(repositoryClass: CampRepository::class)]
+#[ORM\Index(columns: ['isPrototype'])]
 class Camp extends BaseEntity implements BelongsToCampInterface, CopyFromPrototypeInterface {
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => ['read', 'Camp:Periods', 'Period:Days', 'Camp:CampCollaborations', 'CampCollaboration:User'],

--- a/api/src/Entity/CampCollaboration.php
+++ b/api/src/Entity/CampCollaboration.php
@@ -80,6 +80,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\UniqueConstraint(name: 'inviteKeyHash_unique', columns: ['inviteKeyHash'])]
 #[ORM\UniqueConstraint(name: 'user_camp_unique', fields: ['user', 'camp'])]
 #[ORM\UniqueConstraint(name: 'inviteEmail_camp_unique', fields: ['inviteEmail', 'camp'])]
+#[ORM\Index(columns: ['status'])]
 class CampCollaboration extends BaseEntity implements BelongsToCampInterface {
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => ['read', 'CampCollaboration:Camp', 'CampCollaboration:User'],

--- a/api/src/Entity/ScheduleEntry.php
+++ b/api/src/Entity/ScheduleEntry.php
@@ -54,6 +54,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     'end' => 'DATE_ADD({period.start}, {}.endOffset, \'minute\')',
 ])]
 #[ORM\Entity(repositoryClass: ScheduleEntryRepository::class)]
+#[ORM\Index(columns: ['startOffset'])]
+#[ORM\Index(columns: ['endOffset'])]
 class ScheduleEntry extends BaseEntity implements BelongsToCampInterface {
     public const ITEM_NORMALIZATION_CONTEXT = [
         'groups' => ['read', 'ScheduleEntry:Activity'],

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -20,8 +20,15 @@ export default new Router({
       path: '/controls',
       name: 'controls',
       components: {
-        navigation: NavigationDefault,
-        default: () => import(/* webpackChunkName: "register" */ './views/dev/Controls.vue')
+        default: () => import(/* webpackChunkName: "controls" */ './views/dev/Controls.vue')
+      }
+    },
+
+    {
+      path: '/performance',
+      name: 'performance',
+      components: {
+        default: () => import(/* webpackChunkName: "performance" */ './views/dev/Performance.vue')
       }
     },
 

--- a/frontend/src/views/dev/Performance.vue
+++ b/frontend/src/views/dev/Performance.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-container fluid>
+    <content-card title="Config">
+      <v-card-text>
+        <table class="result-table">
+          <tr>
+            <th>Endpoint</th>
+            <th>Collection ms</th>
+            <th>Entity ms</th>
+          </tr>
+          <tr v-for="result in results" :key="result.endpoint">
+            <td>{{ result.endpoint }}</td>
+            <td class="text-right">
+              {{ result.collection }}
+            </td>
+            <td class="text-right">
+              {{ result.entity }}
+            </td>
+          </tr>
+        </table>
+      </v-card-text>
+    </content-card>
+  </v-container>
+</template>
+
+<script>
+
+export default {
+  name: 'Controls',
+  components: {
+
+  },
+  data: () => ({
+    results: []
+
+  }),
+  computed: {
+
+  },
+  async mounted () {
+    const root = await this.api.get()._meta.load
+
+    for (const key of Object.keys(root)) {
+      if (['config', '_meta', '_storeData', 'apiActions'].includes(key)) continue
+
+      if (key.includes('auth') || key.includes('login') || key.includes('reset')) continue
+
+      if (key.includes('user') || key.includes('profile') || key.includes('invitation')) continue
+
+      // const collection = await root[key]()._meta.load
+      // const entity = collection.items[0]._meta.self
+
+      const collection = await this.api.href(root, key)
+
+      const collectionStart = new Date().getTime()
+      const collectionData = await this.axios.get(collection)
+      const collectionEnd = new Date().getTime()
+
+      await this.axios.get(collectionData.data._embedded.items[0]._links.self.href)
+      const entityEnd = new Date().getTime()
+
+      this.results.push({
+        endpoint: key,
+        collection: collectionEnd - collectionStart,
+        entity: entityEnd - collectionEnd
+      })
+    }
+  }
+}
+
+</script>
+
+<style scoped lang="scss">
+.result-table{
+  border:1px black solid;
+  border-collapse: collapse;
+  tr {
+    td, th {
+    border: 1px black solid;
+    padding: 5px;
+  }
+  }
+}
+</style>


### PR DESCRIPTION
add measurement for API endpoints

http://localhost:3000/performance

Measurement taken with XDEBUG_MODE=off and warm cache (2nd run)

Endpoint | Collection ms | Entity ms
-- | -- | --
activities | 388 | 132
contentNodes | 608 | 76
multiSelects | 104 | 75
storyboards | 216 | 82
columnLayouts | 383 | 79
multiSelectOptions | 107 | 70
materialNodes | 209 | 77
singleTexts | 291 | 76
storyboardSections | 188 | 80
days | 75 | 67
categories | 129 | 85
contentTypes | 55 | 51
camps | 2069 | 311
periods | 75 | 134
materialLists | 68 | 62
scheduleEntries | 301 | 86
materialItems | 126 | 75
activityResponsibles | 74 | 69
dayResponsibles | 63 | 64
campCollaborations | 199 | 108
