### PR TITLE
Use more mocking instead of allowing to override final classes

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -49,7 +49,6 @@
         "webonyx/graphql-php": "14.11.8"
     },
     "require-dev": {
-        "dg/bypass-finals": "^1.4",
         "friendsofphp/php-cs-fixer": "3.13.0",
         "hautelook/alice-bundle": "2.11.0",
         "justinrainbow/json-schema": "5.2.12",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "033554114e01ddd0a9e5e016c29ab1a9",
+    "content-hash": "1a7d77e78eb2ebc66068167029052741",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11067,59 +11067,6 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
-        },
-        {
-            "name": "dg/bypass-finals",
-            "version": "v1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dg/bypass-finals.git",
-                "reference": "4c424c3ed359220fce044f35cdf9f48b0089b2ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dg/bypass-finals/zipball/4c424c3ed359220fce044f35cdf9f48b0089b2ca",
-                "reference": "4c424c3ed359220fce044f35cdf9f48b0089b2ca",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.3",
-                "phpstan/phpstan": "^0.12"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                }
-            ],
-            "description": "Removes final keyword from source code on-the-fly and allows mocking of final methods and classes",
-            "keywords": [
-                "finals",
-                "mocking",
-                "phpunit",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "issues": "https://github.com/dg/bypass-finals/issues",
-                "source": "https://github.com/dg/bypass-finals/tree/v1.4.1"
-            },
-            "time": "2022-09-13T17:27:26+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -226,14 +226,9 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
 
         $this->nameConverterMock->method('denormalize')->willReturn('renamedChildren');
 
-        $classMetadata = $this->createMock(ORM\ClassMetadata::class);
-        $classMetadata->method('getAssociationMapping')->with('renamedChildren')->willReturn(['targetEntity' => Child::class, 'mappedBy' => 'parent']);
-        $manager = $this->createMock(EntityManagerInterface::class);
-        $manager->method('getClassMetadata')->willReturn($classMetadata);
-        $this->managerRegistryMock->method('getManagerForClass')->willReturn($manager);
-
         $this->mockRelatedResourceMetadata(['filters' => ['attribute_filter_something_something']]);
         $this->mockRelatedFilterDescription(['parent' => ['strategy' => 'exact']]);
+        $this->mockAssociationMetadata(['targetEntity' => Child::class, 'mappedBy' => 'parent']);
         $this->mockGeneratedRoute();
 
         // when
@@ -257,23 +252,6 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->mockAssociationMetadata(['targetEntity' => Child::class, 'mappedBy' => 'parent']);
         $this->mockRelatedResourceMetadata(['filters' => ['attribute_filter_something_something']]);
         $this->mockRelatedFilterDescription(['some_other_property' => ['strategy' => 'exact']]);
-        $this->mockGeneratedRoute();
-
-        // when
-        $result = $this->normalizer->normalize($resource, null, ['resource_class' => ParentEntity::class]);
-
-        // then
-        $this->shouldNotReplaceChildren($result);
-    }
-
-    public function testNormalizeDoesntReplaceWhenStrategyIsNotExact() {
-        // given
-        $resource = new ParentEntity();
-        $this->mockDecoratedNormalizer();
-        $this->mockNameConverter();
-        $this->mockAssociationMetadata(['targetEntity' => Child::class, 'mappedBy' => 'parent']);
-        $this->mockRelatedResourceMetadata(['filters' => ['attribute_filter_something_something']]);
-        $this->mockRelatedFilterDescription(['parent' => ['strategy' => 'start']]);
         $this->mockGeneratedRoute();
 
         // when
@@ -425,6 +403,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
     protected function mockAssociationMetadata($relationMetadata) {
         $classMetadata = $this->createMock(ORM\ClassMetadata::class);
         $classMetadata->method('getAssociationMapping')->willReturn($relationMetadata);
+        $classMetadata->method('hasAssociation')->willReturn(true);
 
         $manager = $this->createMock(EntityManagerInterface::class);
         $manager->method('getClassMetadata')->willReturn($classMetadata);
@@ -449,9 +428,8 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->nameConverterMock->method('denormalize')->willReturnArgument(0);
     }
 
-    protected function mockRelatedFilterDescription($description) {
-        $this->filterInstance = $this->createMock(SearchFilter::class);
-        $this->filterInstance->method('getDescription')->willReturn($description);
+    protected function mockRelatedFilterDescription($properties) {
+        $this->filterInstance = new SearchFilter($this->managerRegistryMock, $this->iriConverterMock, null, null, $properties);
     }
 
     protected function shouldReplaceChildrenWithLink($result, $link = '/children?parent=%2Fparents%2F123') {

--- a/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
+++ b/api/tests/Serializer/Normalizer/RelatedCollectionLinkNormalizerTest.php
@@ -376,8 +376,7 @@ class RelatedCollectionLinkNormalizerTest extends TestCase {
         $this->mockNameConverter();
         $this->mockAssociationMetadata(['targetEntity' => Child::class, 'mappedBy' => 'parent']);
         $this->mockRelatedResourceMetadata(['filters' => ['attribute_filter_something_something']]);
-        $this->filterInstance = $this->createMock(DateFilter::class);
-        $this->filterInstance->method('getDescription')->willReturn(['filters' => ['attribute_filter_something_something']]);
+        $this->filterInstance = new DateFilter($this->managerRegistryMock, null, ['filters' => ['attribute_filter_something_something']]);
         $this->mockGeneratedRoute();
 
         // when

--- a/api/tests/bootstrap.php
+++ b/api/tests/bootstrap.php
@@ -4,8 +4,6 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-DG\BypassFinals::enable(); // allows mocking of final classes
-
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
If a package vendor specifies a class as final, they really do not expect the class to ever be overridden. Also, adding this package to require-dev allows us to do so in a dev environment, even accidentally outside of tests, and that code will only fail when running in production.
Instead of trying to enable mocking SearchFilter, we can just instantiate it and mock a little more in another place. The test testNormalizeDoesntReplaceWhenStrategyIsNotExact was flawed, because the search strategy is always forced to be "exact" when filtering by an association. For this reason, I removed that test, because it does not make sense to test a primitive field filter in the context of RelatedCollectionLinkNormalizer. This normalizer is only concerned with associations, not with primitive fields.